### PR TITLE
Implement ClientboundPacket on TransferPacket

### DIFF
--- a/src/client/packet/TransferPacket.php
+++ b/src/client/packet/TransferPacket.php
@@ -30,9 +30,10 @@ declare(strict_types=1);
 
 namespace cooldogedev\Spectrum\client\packet;
 
+use pocketmine\network\mcpe\protocol\ClientboundPacket;
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 
-final class TransferPacket extends ProxyPacket
+final class TransferPacket extends ProxyPacket implements ClientboundPacket
 {
     public const NETWORK_ID = ProxyPacketIds::TRANSFER;
 


### PR DESCRIPTION
Right now you can't directly send ``TransferPacket`` to the player network session using ``NetworkSession->sendDataPacket()`` because it doesn't implement ``ClientboundPacket``.  I haven't seen another way to send the player the packet without implementing it, so this PR fixes that by implementing ``ClientboundPacket`` on ``TransferPacket``.